### PR TITLE
Attempt at fixing CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7" ]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Close #51 

Also, use py3.9 as the oldest supported version, and test with more py versions.